### PR TITLE
DOC: Remove "current" from byte-order note and expand it slightly (#2…

### DIFF
--- a/doc/source/user/byteswapping.rst
+++ b/doc/source/user/byteswapping.rst
@@ -61,12 +61,14 @@ is also big-endian).  However, sometimes you need to flip these around.
 
 .. warning::
 
-    Scalars currently do not include byte order information, so extracting
-    a scalar from an array will return an integer in native byte order.
-    Hence:
+    Scalars do not include byte order information, so extracting a scalar from
+    an array will return an integer in native byte order.  Hence:
 
     >>> big_end_arr[0].dtype.byteorder == little_end_u4[0].dtype.byteorder
     True
+
+    NumPy intentionally does not attempt to always preserve byte-order
+    and for example converts to native byte-order in `numpy.concatenate`.
 
 Changing byte ordering
 ======================


### PR DESCRIPTION
…2521)

We don't preserve non-native byte-order and we have no wish to do so. (If someone disagrees, they better wite a NEP ;))
Spell it out, and thus:

closes gh-1866

Co-authored-by: Sebastian Berg <sebastianb@nvidia.com>

<!--         ----------------------------------------------------------------
                MAKE SURE YOUR PR GETS THE ATTENTION IT DESERVES!
                ----------------------------------------------------------------

*  FORMAT IT RIGHT:
      https://www.numpy.org/devdocs/dev/development_workflow.html#writing-the-commit-message

*  IF IT'S A NEW FEATURE OR API CHANGE, TEST THE WATERS:
      https://www.numpy.org/devdocs/dev/development_workflow.html#get-the-mailing-list-s-opinion

*  HIT ALL THE GUIDELINES:
      https://numpy.org/devdocs/dev/index.html#guidelines

*  WHAT TO DO IF WE HAVEN'T GOTTEN BACK TO YOU:
      https://www.numpy.org/devdocs/dev/development_workflow.html#getting-your-pr-reviewed
-->
